### PR TITLE
src/configurationmanager.h: include sys/file.h

### DIFF
--- a/src/configurationmanager.h
+++ b/src/configurationmanager.h
@@ -23,6 +23,10 @@
 #include <map>
 #include <set>
 
+#ifndef _WIN32
+#include <sys/file.h> // LOCK_EX and LOCK_NB
+#endif
+
 #define CONFIGURATIONSTOREDBYVERSION -2
 class ConfigurationManager
 {


### PR DESCRIPTION
This is needed for some non GNU lib c implemetations so that LOCK_EX and
LOCK_NB are defined.